### PR TITLE
README - Remove excess cat in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ for parsing timestamps from the input.
 Examples:
 
   # tail entries since last hour
-  cat /var/log/apache/access.log | tailsince -p 1h
+  tailsince -p 1h /var/log/apache/access.log
 
   # tail entries since 3 days, 6 hours
   tailsince -p 3d6h /var/log/apache/access.log


### PR DESCRIPTION
Another option to avoid the extra program execution is:
`tailsince -p 1h < /var/log/apache/access.log`
